### PR TITLE
исправила ошибки в верстке кнопки Больше статей

### DIFF
--- a/components/Cardlist/CardList.vue
+++ b/components/Cardlist/CardList.vue
@@ -24,7 +24,6 @@ export default {
 <style scoped>
 .card-list {
   padding: 0 60px;
-  margin: 70px auto 140px;
   display: grid;
   justify-content: center;
   grid-template-columns: 300px 300px 300px 300px;

--- a/components/Stories.vue
+++ b/components/Stories.vue
@@ -3,8 +3,8 @@
     <app-section-title class="stories__title"
       >Истории неизлечимых привычек</app-section-title
     >
-    <app-cardlist class="eight-cards" :cards="stories.slice(0, 8)" />
-    <app-cardlist class="nine-cards" :cards="stories.slice(0, 9)" />
+    <app-cardlist class="cardlist eight-cards" :cards="stories.slice(0, 8)" />
+    <app-cardlist class="cardlist nine-cards" :cards="stories.slice(0, 9)" />
     <app-more-articles />
   </div>
 </template>
@@ -36,13 +36,24 @@ export default {
   max-width: 1440px;
   margin: 0 auto;
 }
+.cardlist {
+  margin: 70px auto 70px;
+}
 .stories__title {
   max-width: 413px;
 }
 .nine-cards {
   display: none;
 }
+@media screen and (max-width: 1279px) {
+  .cardlist {
+    margin: 60px auto 60px;
+  }
+}
 @media screen and (max-width: 1023px) {
+  .cardlist {
+    margin: 46px auto 46px;
+  }
   .nine-cards {
     display: grid;
   }
@@ -51,6 +62,9 @@ export default {
   }
 }
 @media screen and (max-width: 767px) {
+  .cardlist {
+    margin: 60px auto 40px;
+  }
   .eight-cards {
     display: grid;
   }
@@ -59,6 +73,9 @@ export default {
   }
 }
 @media screen and (max-width: 500px) {
+  .cardlist {
+    margin: 40px auto 40px;
+  }
   .eight-cards {
     display: flex;
   }

--- a/pages/stories/_id.vue
+++ b/pages/stories/_id.vue
@@ -91,7 +91,7 @@
             stories.slice($route.params.id, parseInt($route.params.id) + 2)
           "
         />
-        <app-more-articles href="#" />
+        <app-more-articles class="more-articles" href="#" />
       </div>
     </app-container>
   </div>
@@ -228,9 +228,14 @@ export default {
 }
 .three-cards {
   display: none;
+  margin: 0 auto;
 }
 .two-cards {
   display: none;
+  margin: 0 auto;
+}
+.more-articles {
+  margin: 70px auto 100px;
 }
 @media screen and (max-width: 1280px) {
   .story__banner {
@@ -251,18 +256,18 @@ export default {
     font-size: 20px;
     line-height: 28px;
   }
+  .story__share_social {
+    margin: 60px auto 150px;
+  }
   .story__more-articles {
     margin: 60px auto 90px;
     padding: 29px;
   }
-  .four-cards {
-    display: none;
-  }
-  .three-cards {
-    display: grid;
+  .more-articles {
+  margin: 60px auto 90px;
   }
 }
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1023px) {
   .story__banner {
     padding: 100px 0 90px;
   }
@@ -291,8 +296,17 @@ export default {
     line-height: 22px;
     margin: 46px auto 120px;
   }
+  .more-articles {
+    margin: 46px auto 80px;
+  }
+  .four-cards {
+    display: none;
+  }
+  .three-cards {
+    display: grid;
+  }
 }
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 767px) {
   .story__banner {
     margin: 80px 0 100px;
     padding: 0;
@@ -354,10 +368,16 @@ export default {
   .two-cards {
     display: grid;
   }
+  .more-articles {
+    margin: 40px auto 80px;
+  }
 }
 @media screen and (max-width: 500px) {
   .two-cards {
     display: flex;
+  }
+  .story__share_social {
+    margin: 40px auto 100px;
   }
 }
 @media screen and (max-width: 320px) {
@@ -387,6 +407,9 @@ export default {
     font-size: 13px;
     line-height: 16px;
     margin: 60px auto 100px;
+  }
+  .more-articles {
+    margin: 40px auto 50px;
   }
 }
 </style>

--- a/pages/stories/index.vue
+++ b/pages/stories/index.vue
@@ -4,7 +4,7 @@
       >Истории неизлечимых привычек</app-section-title
     >
     <app-search />
-    <app-cardlist :cards="page" />
+    <app-cardlist :cards="page" class="cardlist" />
     <app-pagination
       :storiesInTotal="stories.length"
       :storiesPerPage="storiesPerPage"
@@ -79,6 +79,9 @@ export default {
   color: #000;
   text-align: left;
   margin-left: 60px;
+}
+.cardlist {
+  margin: 70px auto 140px;
 }
 @media screen and (max-width: 1379px) {
   .stories__title {


### PR DESCRIPTION
1 большой отступ между карточками с историями и кнопкой "больше статей" на главной странице. даже по макету видно что этот отступ должен быть меньше
2 если перейти, например, на страницу http://localhost:3000/stories/7, то внизу можно заметить что кнопка "больше" статей (в отличие от пункта 1) прижата к контейнерам с фотками и к подвалу соответственно. подумайте в сторону прокидывания микса со стороны внешнего блока

вот эти две ошибки исправила